### PR TITLE
Fallback to text parser if unknown text provided

### DIFF
--- a/f8a_tagger/parsers/core_parser.py
+++ b/f8a_tagger/parsers/core_parser.py
@@ -34,7 +34,9 @@ class CoreParser(object):
         'restructuredtext': ReStructuredTextParser,
         'textile': TextileParser,
         'txt': TextParser,
-        'html': HtmlParser
+        'html': HtmlParser,
+        # fallback to raw text when unknown format provided
+        'unknown': TextParser
     }
 
     # based on https://github.com/github/markup#markups


### PR DESCRIPTION
Workers in fabric8-analytics core report 'unknown' if README type cannot be determined. Fallback to text parser in such cases.