### PR TITLE
Add docstrings into setup.py + fix minor linter issues in the f8a_tagger_cli module

### DIFF
--- a/f8a_tagger_cli.py
+++ b/f8a_tagger_cli.py
@@ -44,7 +44,8 @@ def _print_result(result, output_file, fmt=None):
 
 
 @click.group()
-@click.option('-v', '--verbose', count=True, help='Level of verbosity, can be applied multiple times.')
+@click.option('-v', '--verbose', count=True,
+              help='Level of verbosity, can be applied multiple times.')
 def cli(verbose=0):
     """Tagger for fabric8-analytics."""
     # hack based on num values of logging.DEBUG, logging.INFO, ...
@@ -117,7 +118,8 @@ def cli_collect(**kwargs):
 @click.option('--no-synonyms',
               help='Do not compute synonyms.')
 @click.option('--occurrence-count-filter', type=int,
-              help="Filter out synonyms with low occurrence count (default: %d)." % defaults.OCCURRENCE_COUNT_FILTER)
+              help="Filter out synonyms with low occurrence count (default: %d)." %
+              defaults.OCCURRENCE_COUNT_FILTER)
 def cli_aggregate(**kwargs):
     """Aggregate keywords to a single file."""
     output_keywords_file = kwargs.pop('output_keywords_file')

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+"""Package configuration module."""
 
 import os
 import sys
@@ -11,6 +12,7 @@ NAME = 'f8a_tagger'
 
 
 def get_requirements():
+    """Read all requirements from the manifest file."""
     with open('requirements.txt') as fd:
         return fd.read().splitlines()
 


### PR DESCRIPTION
Those two changes are needed to check setup.py and f8a_tagger_cli.py modules using Python linter and documentation string checker.

Related to: https://github.com/openshiftio/openshift.io/issues/1233